### PR TITLE
Feature allow use with rvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ module.exports = function(config) {
         return cacheId;
       },
 
+      // Setting this option to true will run the haml command in a login shell.
+      // This will enable you to use the Ruby set by RVM instead of the system Ruby
+      loginShell: true,
+
       // setting this option will create only a single module that contains templates
       // from all the files, so you can load them all with module('foo')
       moduleName: 'foo'

--- a/lib/haml2js.js
+++ b/lib/haml2js.js
@@ -37,7 +37,7 @@ var createHaml2JsPreprocessor = function(logger, basePath, config) {
     var hamlPath = cacheIdFromPath(file.originalPath.replace(basePath + '/', ''));
     var htmlPath = hamlPath.replace('.haml', '.html');
 
-    file.path = file.path + '.js';
+    file.path = file.originalPath + '.js';
 
     if (moduleName) {
       exec('haml ' + file.originalPath, function (err, stdout, stderr) {

--- a/lib/haml2js.js
+++ b/lib/haml2js.js
@@ -35,7 +35,7 @@ var createHaml2JsPreprocessor = function(logger, basePath, config) {
     log.debug('Processing "%s".', file.originalPath);
 
     var hamlPath = cacheIdFromPath(file.originalPath.replace(basePath + '/', ''));
-    var htmlPath = hamlPath.replace('.haml', '.html');
+    var htmlPath = hamlPath.replace(/\.haml|\.html\.haml/, '.html');
 
     file.path = file.originalPath + '.js';
 

--- a/lib/haml2js.js
+++ b/lib/haml2js.js
@@ -26,6 +26,7 @@ var createHaml2JsPreprocessor = function(logger, basePath, config) {
   var log = logger.create('preprocessor.haml2js');
   var moduleName = config.moduleName;
   var stripPrefix = new RegExp('^' + (config.stripPrefix || ''));
+  var loginShell = config.loginShell;
   var prependPrefix = config.prependPrefix || '';
   var cacheIdFromPath = config && config.cacheIdFromPath || function(filepath) {
     return prependPrefix + filepath.replace(stripPrefix, '');
@@ -39,12 +40,28 @@ var createHaml2JsPreprocessor = function(logger, basePath, config) {
 
     file.path = file.originalPath + '.js';
 
+    var hamlCommand;
+    
+    if(loginShell){
+      hamlCommand = 'bash -lc "haml ' + file.originalPath + '"';
+    }
+    else{
+      hamlCommand = 'haml ' + file.originalPath;
+    }
+
+    log.debug('Running ' + hamlCommand);
+
     if (moduleName) {
-      exec('haml ' + file.originalPath, function (err, stdout, stderr) {
+      exec(hamlCommand, function (err, stdout, stderr) {
+        if( stderr ){ log.error( stderr ) };
+
         done(util.format(SINGLE_MODULE_TPL, moduleName, moduleName, htmlPath, escapeContent(stdout)));
+
       });
     } else {
-      exec('haml ' + file.originalPath, function (err, stdout, stderr) {
+      exec(hamlCommand, function (err, stdout, stderr) {
+        if( stderr ){ log.error( stderr ) };
+
         done(util.format(TEMPLATE, htmlPath, htmlPath, escapeContent(stdout)));
       });
     }


### PR DESCRIPTION
Hi,
I needed to be able to use this with RVM, but the haml command was being run by the system Ruby. I have added an option to run the command via a login shell. This enables my .bash_profile script to run and add RVM as a script.

I haven't tested this usage on Mac OS or on a system that doesn't use RVM, however the new feature is disabled by default.

Hope it's useful.
