### PR TITLE
Use exec-sync package to block until haml finishes.

### DIFF
--- a/lib/haml2js.js
+++ b/lib/haml2js.js
@@ -35,7 +35,7 @@ var createHaml2JsPreprocessor = function(logger, basePath, config) {
     log.debug('Processing "%s".', file.originalPath);
 
     var hamlPath = cacheIdFromPath(file.originalPath.replace(basePath + '/', ''));
-    var htmlPath = hamlPath.replace('.haml', '.html');
+    var htmlPath = hamlPath.replace(/\.haml|\.html\.haml/, '.html');
 
     file.path = file.path + '.js';
 

--- a/lib/haml2js.js
+++ b/lib/haml2js.js
@@ -1,5 +1,5 @@
 var util = require('util');
-var exec = require('child_process').exec;
+var execSync = require('child_process').execSync;
 
 var TEMPLATE = 'angular.module(\'%s\', []).run(function($templateCache) {\n' +
     '  $templateCache.put(\'%s\',\n    \'%s\');\n' +
@@ -35,18 +35,23 @@ var createHaml2JsPreprocessor = function(logger, basePath, config) {
     log.debug('Processing "%s".', file.originalPath);
 
     var hamlPath = cacheIdFromPath(file.originalPath.replace(basePath + '/', ''));
-    var htmlPath = hamlPath.replace('.haml', '.html');
+    var htmlPath = hamlPath.replace(/\.haml|\.html\.haml/, '.html');
 
     file.path = file.path + '.js';
-
-    if (moduleName) {
-      exec('haml ' + file.originalPath, function (err, stdout, stderr) {
-        done(util.format(SINGLE_MODULE_TPL, moduleName, moduleName, htmlPath, escapeContent(stdout)));
-      });
-    } else {
-      exec('haml ' + file.originalPath, function (err, stdout, stderr) {
-        done(util.format(TEMPLATE, htmlPath, htmlPath, escapeContent(stdout)));
-      });
+  
+    try {
+      var stdout = execSync('haml ' + file.originalPath);
+      var escapedContents = escapeContent(stdout.toString());
+      var results;
+      if (moduleName) {
+        results = util.format(SINGLE_MODULE_TPL, moduleName, moduleName, htmlPath, escapedContents);
+      } else {
+        results = util.format(TEMPLATE, htmlPath, htmlPath, escapedContents);
+      }
+      done(null, results);
+    } catch (e) {
+      log.error('%s in %s', e.message || e.name, file.originalPath);
+      done(e, null);
     }
   };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-ng-haml2js-preprocessor",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A Karma plugin. Compile AngularJS templates written in HAML to JavaScript on the fly.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Though not very node like it is appropriate for a command line interface to block.  This is to prevent the system from getting overloaded by haml processes if there are a lot of haml files.
