### PR TITLE
Async exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ module.exports = function(config) {
       '**/*.haml'
     ],
 
-    ngHaml2JsPreprocessor: {
+    ngHaml2jsPreprocessor: {
       // strip this from the file path
       stripPrefix: 'public/',
       // prepend this to the

--- a/lib/haml2js.js
+++ b/lib/haml2js.js
@@ -35,7 +35,7 @@ var createHaml2JsPreprocessor = function(logger, basePath, config) {
     log.debug('Processing "%s".', file.originalPath);
 
     var hamlPath = cacheIdFromPath(file.originalPath.replace(basePath + '/', ''));
-    var htmlPath = hamlPath.replace('.haml', '.html');
+    var htmlPath = hamlPath.replace(/\.haml|\.html\.haml/, '.html');
 
     file.path = file.path + '.js';
 

--- a/lib/haml2js.js
+++ b/lib/haml2js.js
@@ -1,5 +1,6 @@
 var util = require('util');
-var execSync = require('child_process').execSync;
+var exec = require('child_process').exec;
+var async = require('async');
 
 var TEMPLATE = 'angular.module(\'%s\', []).run(function($templateCache) {\n' +
     '  $templateCache.put(\'%s\',\n    \'%s\');\n' +
@@ -30,30 +31,39 @@ var createHaml2JsPreprocessor = function(logger, basePath, config) {
   var cacheIdFromPath = config && config.cacheIdFromPath || function(filepath) {
     return prependPrefix + filepath.replace(stripPrefix, '');
   };
+  var queue = async.queue(function (task, callback) {
+    process(task.content, task.file, function () {
+      task.done.apply(null, arguments);
+      callback();
+    });
+  }, config.civisConcurrency || 2);
 
-  return function(content, file, done) {
+  return function asyncProcess(content, file, done) {
+    queue.push({
+      content: content,
+      file: file,
+      done: done
+    });
+  };
+
+  function process(content, file, done) {
     log.debug('Processing "%s".', file.originalPath);
 
     var hamlPath = cacheIdFromPath(file.originalPath.replace(basePath + '/', ''));
     var htmlPath = hamlPath.replace(/\.haml|\.html\.haml/, '.html');
 
     file.path = file.path + '.js';
-  
-    try {
-      var stdout = execSync('haml ' + file.originalPath);
-      var escapedContents = escapeContent(stdout.toString());
-      var results;
-      if (moduleName) {
-        results = util.format(SINGLE_MODULE_TPL, moduleName, moduleName, htmlPath, escapedContents);
-      } else {
-        results = util.format(TEMPLATE, htmlPath, htmlPath, escapedContents);
-      }
-      done(null, results);
-    } catch (e) {
-      log.error('%s in %s', e.message || e.name, file.originalPath);
-      done(e, null);
+
+    if (moduleName) {
+      exec('haml ' + file.originalPath, function (err, stdout, stderr) {
+        done(util.format(SINGLE_MODULE_TPL, moduleName, moduleName, htmlPath, escapeContent(stdout)));
+      });
+    } else {
+      exec('haml ' + file.originalPath, function (err, stdout, stderr) {
+        done(util.format(TEMPLATE, htmlPath, htmlPath, escapeContent(stdout)));
+      });
     }
-  };
+  }
 };
 
 createHaml2JsPreprocessor.$inject = ['logger', 'config.basePath', 'config.ngHaml2JsPreprocessor'];

--- a/lib/haml2js.js
+++ b/lib/haml2js.js
@@ -1,5 +1,5 @@
 var util = require('util');
-var exec = require('child_process').exec;
+var execSync = require('child_process').execSync;
 
 var TEMPLATE = 'angular.module(\'%s\', []).run(function($templateCache) {\n' +
     '  $templateCache.put(\'%s\',\n    \'%s\');\n' +
@@ -35,18 +35,23 @@ var createHaml2JsPreprocessor = function(logger, basePath, config) {
     log.debug('Processing "%s".', file.originalPath);
 
     var hamlPath = cacheIdFromPath(file.originalPath.replace(basePath + '/', ''));
-    var htmlPath = hamlPath.replace('.haml', '.html');
+    var htmlPath = hamlPath.replace(/\.haml|\.html\.haml/, '.html');
 
     file.path = file.path + '.js';
-
-    if (moduleName) {
-      exec('haml ' + file.originalPath, function (err, stdout, stderr) {
-        done(util.format(SINGLE_MODULE_TPL, moduleName, moduleName, htmlPath, escapeContent(stdout)));
-      });
-    } else {
-      exec('haml ' + file.originalPath, function (err, stdout, stderr) {
-        done(util.format(TEMPLATE, htmlPath, htmlPath, escapeContent(stdout)));
-      });
+  
+    try {
+      var stdout = execSync('haml ' + file.originalPath);
+      var escapedContents = escapeContent(stdout.toString());
+      var results;
+      if (moduleName) {
+        results = util.format(SINGLE_MODULE_TPL, moduleName, moduleName, htmlPath, escapedContents);
+      } else {
+        results = util.format(TEMPLATE, htmlPath, htmlPath, escapedContents);
+      }
+      done(null, results);
+    } catch (e) {
+      log.error('%s in %s', e.message || e.name, file.originalPath);
+      done(e, null);
     }
   };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-ng-haml2js-preprocessor",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A Karma plugin. Compile AngularJS templates written in HAML to JavaScript on the fly.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "haml2js"
   ],
   "author": "Cody Sims <cody@codysims.com>",
-  "dependencies": {},
+  "dependencies": {
+    "async": "^1.4.2"
+  },
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-simple-mocha": "~0.4",
@@ -29,7 +31,7 @@
     "grunt-bump": "~0.0.7",
     "grunt-auto-release": "~0.0.2",
     "haml": "~0.4.3"
-},
+  },
   "peerDependencies": {
     "karma": ">=0.9"
   },


### PR DESCRIPTION
Uses an async queue to process haml files. It shoud be good enough for our use case, although it stores all file contents in memory while waiting in the queue (better than a fork bomb I guess).

I added a non-standard parameter civisConcurrency just in case we want to fine-tune it, but I think 2 ruby processes is enough.
