### PR TITLE
fix: explicit annotations for $templateCache dependency

### DIFF
--- a/lib/haml2js.js
+++ b/lib/haml2js.js
@@ -1,9 +1,9 @@
 var util = require('util');
 var exec = require('child_process').exec;
 
-var TEMPLATE = 'angular.module(\'%s\', []).run(function($templateCache) {\n' +
+var TEMPLATE = 'angular.module(\'%s\', []).run([\'$templateCache\', function($templateCache) {\n' +
     '  $templateCache.put(\'%s\',\n    \'%s\');\n' +
-    '});\n';
+    '}]);\n';
 
 var SINGLE_MODULE_TPL = '(function(module) {\n' +
     'try {\n' +
@@ -11,9 +11,9 @@ var SINGLE_MODULE_TPL = '(function(module) {\n' +
     '} catch (e) {\n' +
     '  module = angular.module(\'%s\', []);\n' +
     '}\n' +
-    'module.run(function($templateCache) {\n' +
+    'module.run([\'$templateCache\', function($templateCache) {\n' +
     '  $templateCache.put(\'%s\',\n    \'%s\');\n' +
-    '});\n' +
+    '}]);\n' +
     '})();\n';
 
 var escapeContent = function(content) {

--- a/test/helpers/template_cache.coffee
+++ b/test/helpers/template_cache.coffee
@@ -7,7 +7,7 @@ module.exports = (chai, utils) ->
       templates = @templates = {}
 
     run: (block) ->
-      block
+      block[1] # Block is an annotation array ["$templateCache", function($templateCache) {..}]
         put: (id, content) =>
           @templates[id] = content
 


### PR DESCRIPTION
Allow test environment to use strict dependency injection : https://github.com/karma-runner/karma-ng-html2js-preprocessor/pull/63
